### PR TITLE
Add Resources link section to front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,8 +29,30 @@
 			<main class="lightgray">
 				<section>
 					<div class="short-description">
-						<p>GoToSocial is an <a href="https://activitypub.rocks/">ActivityPub</a> social network server, written in Golang.</p>
-						<p>With GoToSocial, you can keep in touch with your friends, post, read, and share images and articles. All without being tracked or advertised to!</p>
+						<p>GoToSocial is an <a href="https://activitypub.rocks/">ActivityPub</a> social network server (compatible with <cite>Mastodon</cite>), written in Golang.</p>
+						<p>
+							With GoToSocial, you can keep in touch with your friends, post, read, and share images and articles.
+							<em>You</em> self-host and control your social network presence!
+							All without being tracked or advertised to!
+						</p>
+					</div>
+				</section>
+				<section>
+					<h2>
+						Resources
+					</h2>
+					<div>
+						<ul>
+							<li>
+								<a href="https://docs.gotosocial.org/en/latest/">Documentation</a>
+								<ul>
+									<li><a href="https://docs.gotosocial.org/en/latest/installation_guide/">Installation guide</a> (single-binary server or Docker)</li>
+								</ul>
+							</li>
+							<li>Source code on <a href="https://github.com/superseriousbusiness/gotosocial">GitHub</a></li>
+							<li>Follow <a href="https://gts.superseriousbusiness.org/@gotosocial">GoToSocial on the Fediverse</a> for updates and announcements</li>
+							<li><a href="https://opencollective.com/gotosocial">Community funding</a></li>
+						</ul>
 					</div>
 				</section>
 			</main>


### PR DESCRIPTION
Hi. Just a small contribution to help people discover and get started with GtS.

* Link to GitHub, documentation, and OpenCollective.
* Add “Mastodon”, “self-host”, and “Docker” keywords (project SEO).