### PR TITLE
Update repository hyperlinks

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
 						<p>GoToSocial's niche is small or single-user instances running on low-powered devices, like single-board computers or old laptops repurposed as home servers.</p>
 						<p>Our focus is on providing lightweight software which is simple to install and maintain, and has good security and sensible defaults out of the box.</p>
 						<p>The system requirements are <a href="https://docs.gotosocial.org/en/latest/getting_started/#server-vps">right here</a>.</p>
-						<p>Other GoToSocial features are <a href="https://github.com/superseriousbusiness/gotosocial#features">here</a>.</p>
+						<p>Other GoToSocial features are <a href="https://codeberg.org/superseriousbusiness/gotosocial#features">here</a>.</p>
 					</div>
 				</section>
 				<h2>Is there a flagship instance I can join?</h2>

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
 				<a href="https://gts.superseriousbusiness.org/@gotosocial" class="nounderline">Official account</a>
 			</div>
 			<div>
-				Code: <a href="https://github.com/superseriousbusiness/gotosocial" class="nounderline">GitHub</a> / <a href="https://codeberg.org/superseriousbusiness/gotosocial" class="nounderline">Codeberg</a>
+				Code: <a href="https://codeberg.org/superseriousbusiness/gotosocial" class="nounderline">Codeberg</a> / <a href="https://github.com/superseriousbusiness/gotosocial" class="nounderline">GitHub</a>
 			</div>
 		</footer>
 	</div>


### PR DESCRIPTION
This PR updates the Git repository hyperlinks to favour Codeberg over the GitHub repo, which is now just a mirror.